### PR TITLE
Add export action

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -803,8 +803,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -6148,6 +6150,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vinylvault"
 version = "2026.3.4"
 dependencies = [
+ "chrono",
  "dirs",
  "env_logger",
  "futures",
@@ -6170,6 +6173,8 @@ dependencies = [
  "tauri-plugin-opener",
  "unicode-normalization",
  "unidecode",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -7382,6 +7387,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -39,3 +39,6 @@ unidecode = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 semver = "1.0"
 futures = "0.3"
+chrono = "0.4"
+walkdir = "2.5"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/app/src-tauri/src/archive.rs
+++ b/app/src-tauri/src/archive.rs
@@ -7,6 +7,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use walkdir::WalkDir;
 use zip::write::FileOptions;
 
+use crate::db;
+
 pub fn create_archive_with_date_suffix(data_dir: &Path, db_path: &Path) -> Result<PathBuf, String> {
     if !data_dir.exists() {
         return Err(format!(
@@ -102,6 +104,8 @@ fn make_db_snapshot_with_vacuum_into(db_path: &Path) -> Result<TempDbSnapshot, S
 
     let conn = Connection::open(db_path)
         .map_err(|e| format!("Failed to open database '{}': {}", db_path.display(), e))?;
+    db::register_spanish_collation(&conn)
+        .map_err(|e| format!("Failed to register SPANISH collation: {}", e))?;
 
     conn.execute(
         "VACUUM INTO ?1",

--- a/app/src-tauri/src/archive.rs
+++ b/app/src-tauri/src/archive.rs
@@ -1,15 +1,24 @@
 use chrono::Local;
-use std::fs::File;
-use std::io::{Read, Write};
+use rusqlite::Connection;
+use std::fs::{self, File, OpenOptions};
+use std::io::{copy, BufReader};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use walkdir::WalkDir;
 use zip::write::FileOptions;
 
-pub fn create_archive_with_date_suffix(data_dir: &Path) -> Result<PathBuf, String> {
+pub fn create_archive_with_date_suffix(data_dir: &Path, db_path: &Path) -> Result<PathBuf, String> {
     if !data_dir.exists() {
         return Err(format!(
             "Data directory does not exist: {}",
             data_dir.display()
+        ));
+    }
+
+    if !db_path.exists() {
+        return Err(format!(
+            "Database file does not exist: {}",
+            db_path.display()
         ));
     }
 
@@ -26,23 +35,110 @@ pub fn create_archive_with_date_suffix(data_dir: &Path) -> Result<PathBuf, Strin
         .filter(|name| !name.trim().is_empty())
         .unwrap_or("discos");
 
-    let date_suffix = Local::now().format("%Y%m%d").to_string();
-    let archive_name = format!("{}_{}.zip", dir_name, date_suffix);
-    let archive_parent = data_dir.parent().unwrap_or(data_dir);
-    let archive_path = archive_parent.join(archive_name);
-
-    create_zip_from_directory(data_dir, &archive_path)?;
-    Ok(archive_path)
-}
-
-fn create_zip_from_directory(source_dir: &Path, archive_path: &Path) -> Result<(), String> {
-    let archive_file = File::create(archive_path).map_err(|e| {
+    let source_dir = fs::canonicalize(data_dir).map_err(|e| {
         format!(
-            "Failed to create archive '{}': {}",
-            archive_path.display(),
+            "Failed to canonicalize data directory '{}': {}",
+            data_dir.display(),
             e
         )
     })?;
+    let archive_path = build_unique_archive_path(&source_dir, dir_name)?;
+
+    let db_snapshot = make_db_snapshot_with_vacuum_into(db_path)?;
+    create_zip_from_directory(&source_dir, &archive_path, db_path, db_snapshot.path())?;
+
+    Ok(archive_path)
+}
+
+fn build_unique_archive_path(source_dir: &Path, dir_name: &str) -> Result<PathBuf, String> {
+    let archive_parent = source_dir.parent().ok_or_else(|| {
+        format!(
+            "Cannot determine a safe archive destination outside source directory '{}'",
+            source_dir.display()
+        )
+    })?;
+
+    let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
+    for counter in 0..=9999u32 {
+        let suffix = if counter == 0 {
+            timestamp.clone()
+        } else {
+            format!("{}_{:02}", timestamp, counter)
+        };
+        let candidate = archive_parent.join(format!("{}_{}.zip", dir_name, suffix));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(format!(
+        "Could not allocate a unique archive filename in '{}'",
+        archive_parent.display()
+    ))
+}
+
+struct TempDbSnapshot {
+    path: PathBuf,
+}
+
+impl TempDbSnapshot {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDbSnapshot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn make_db_snapshot_with_vacuum_into(db_path: &Path) -> Result<TempDbSnapshot, String> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("System clock error: {}", e))?
+        .as_nanos();
+    let snapshot_path = std::env::temp_dir().join(format!("vinylvault-snapshot-{nanos}.sqlite"));
+
+    let conn = Connection::open(db_path)
+        .map_err(|e| format!("Failed to open database '{}': {}", db_path.display(), e))?;
+
+    conn.execute(
+        "VACUUM INTO ?1",
+        [snapshot_path.to_string_lossy().to_string()],
+    )
+    .map_err(|e| format!("Failed to create DB snapshot with VACUUM INTO: {}", e))?;
+
+    Ok(TempDbSnapshot {
+        path: snapshot_path,
+    })
+}
+
+fn create_zip_from_directory(
+    source_dir: &Path,
+    archive_path: &Path,
+    db_path: &Path,
+    db_snapshot_path: &Path,
+) -> Result<(), String> {
+    if archive_path.starts_with(source_dir) {
+        return Err(format!(
+            "Archive destination '{}' is inside source directory '{}', which is unsafe",
+            archive_path.display(),
+            source_dir.display()
+        ));
+    }
+
+    let archive_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(archive_path)
+        .map_err(|e| {
+            format!(
+                "Failed to create archive '{}': {}",
+                archive_path.display(),
+                e
+            )
+        })?;
     let mut zip = zip::ZipWriter::new(archive_file);
 
     let dir_options = FileOptions::default().unix_permissions(0o755);
@@ -50,13 +146,15 @@ fn create_zip_from_directory(source_dir: &Path, archive_path: &Path) -> Result<(
         .compression_method(zip::CompressionMethod::Deflated)
         .unix_permissions(0o644);
 
-    let mut buffer = Vec::new();
-
     for entry in WalkDir::new(source_dir).follow_links(false) {
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
 
         if path == source_dir {
+            continue;
+        }
+
+        if path == archive_path {
             continue;
         }
 
@@ -78,14 +176,22 @@ fn create_zip_from_directory(source_dir: &Path, archive_path: &Path) -> Result<(
         if entry.file_type().is_file() {
             zip.start_file(rel_name.clone(), file_options)
                 .map_err(|e| format!("Failed to add file '{}' to zip: {}", rel_name, e))?;
-            let mut input_file = File::open(path)
-                .map_err(|e| format!("Failed to open file '{}': {}", path.display(), e))?;
-            buffer.clear();
-            input_file
-                .read_to_end(&mut buffer)
-                .map_err(|e| format!("Failed to read file '{}': {}", path.display(), e))?;
-            zip.write_all(&buffer)
-                .map_err(|e| format!("Failed to write file '{}' to zip: {}", rel_name, e))?;
+
+            let source_file_for_zip = if path == db_path {
+                db_snapshot_path
+            } else {
+                path
+            };
+            let mut input_file = File::open(source_file_for_zip).map_err(|e| {
+                format!(
+                    "Failed to open file '{}': {}",
+                    source_file_for_zip.display(),
+                    e
+                )
+            })?;
+            let mut input_reader = BufReader::new(&mut input_file);
+            copy(&mut input_reader, &mut zip)
+                .map_err(|e| format!("Failed to stream file '{}' to zip: {}", rel_name, e))?;
         }
     }
 
@@ -103,33 +209,59 @@ fn create_zip_from_directory(source_dir: &Path, archive_path: &Path) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::ops::Deref;
 
-    fn make_temp_dir(label: &str) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time went backwards")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!("vinylvault-archive-{label}-{nanos}"));
-        fs::create_dir_all(&path).expect("failed to create temp directory");
-        path
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new(label: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time went backwards")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("vinylvault-archive-{label}-{nanos}"));
+            fs::create_dir_all(&path).expect("failed to create temp directory");
+            Self { path }
+        }
+    }
+
+    impl Deref for TestTempDir {
+        type Target = Path;
+
+        fn deref(&self) -> &Self::Target {
+            &self.path
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
     }
 
     #[test]
     fn create_archive_includes_db_and_cover_files() {
-        let root = make_temp_dir("content");
+        let root = TestTempDir::new("content");
         let data_dir = root.join("discos");
         let cover_subdir = data_dir.join("covers").join("ab");
         fs::create_dir_all(&cover_subdir).expect("failed to create cover subdir");
 
         let db_path = data_dir.join("discos.sqlite");
+        let conn = Connection::open(&db_path).expect("failed to create test db");
+        conn.execute("CREATE TABLE t (v TEXT)", [])
+            .expect("failed to create table in test db");
+        conn.execute("INSERT INTO t (v) VALUES ('ok')", [])
+            .expect("failed to insert test row");
+
         let cover_path = cover_subdir.join("album_cd_hash.jpg");
-        fs::write(&db_path, b"sqlite-data").expect("failed to write db file");
         fs::write(&cover_path, b"cover-data").expect("failed to write cover file");
 
         let archive_path =
-            create_archive_with_date_suffix(&data_dir).expect("failed to create archive");
+            create_archive_with_date_suffix(&data_dir, &db_path).expect("failed to create archive");
         assert!(archive_path.exists());
 
         let archive_file = File::open(&archive_path).expect("failed to open archive");
@@ -138,5 +270,28 @@ mod tests {
 
         assert!(archive.by_name("discos.sqlite").is_ok());
         assert!(archive.by_name("covers/ab/album_cd_hash.jpg").is_ok());
+    }
+
+    #[test]
+    fn create_archive_twice_does_not_overwrite_previous_archive() {
+        let root = TestTempDir::new("unique-name");
+        let data_dir = root.join("discos");
+        fs::create_dir_all(&data_dir).expect("failed to create data directory");
+
+        let db_path = data_dir.join("discos.sqlite");
+        let conn = Connection::open(&db_path).expect("failed to create test db");
+        conn.execute("CREATE TABLE t (v TEXT)", [])
+            .expect("failed to create table in test db");
+        conn.execute("INSERT INTO t (v) VALUES ('ok')", [])
+            .expect("failed to insert test row");
+
+        let first_path =
+            create_archive_with_date_suffix(&data_dir, &db_path).expect("first archive failed");
+        let second_path =
+            create_archive_with_date_suffix(&data_dir, &db_path).expect("second archive failed");
+
+        assert!(first_path.exists());
+        assert!(second_path.exists());
+        assert_ne!(first_path, second_path);
     }
 }

--- a/app/src-tauri/src/archive.rs
+++ b/app/src-tauri/src/archive.rs
@@ -44,10 +44,22 @@ pub fn create_archive_with_date_suffix(data_dir: &Path, db_path: &Path) -> Resul
             e
         )
     })?;
+    let canonical_db_path = fs::canonicalize(db_path).map_err(|e| {
+        format!(
+            "Failed to canonicalize database path '{}': {}",
+            db_path.display(),
+            e
+        )
+    })?;
     let archive_path = build_unique_archive_path(&source_dir, dir_name)?;
 
-    let db_snapshot = make_db_snapshot_with_vacuum_into(db_path)?;
-    create_zip_from_directory(&source_dir, &archive_path, db_path, db_snapshot.path())?;
+    let db_snapshot = make_db_snapshot_with_vacuum_into(&canonical_db_path)?;
+    create_zip_from_directory(
+        &source_dir,
+        &archive_path,
+        &canonical_db_path,
+        db_snapshot.path(),
+    )?;
 
     Ok(archive_path)
 }

--- a/app/src-tauri/src/archive.rs
+++ b/app/src-tauri/src/archive.rs
@@ -1,0 +1,142 @@
+use chrono::Local;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+use zip::write::FileOptions;
+
+pub fn create_archive_with_date_suffix(data_dir: &Path) -> Result<PathBuf, String> {
+    if !data_dir.exists() {
+        return Err(format!(
+            "Data directory does not exist: {}",
+            data_dir.display()
+        ));
+    }
+
+    if !data_dir.is_dir() {
+        return Err(format!(
+            "Data path is not a directory: {}",
+            data_dir.display()
+        ));
+    }
+
+    let dir_name = data_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("discos");
+
+    let date_suffix = Local::now().format("%Y%m%d").to_string();
+    let archive_name = format!("{}_{}.zip", dir_name, date_suffix);
+    let archive_parent = data_dir.parent().unwrap_or(data_dir);
+    let archive_path = archive_parent.join(archive_name);
+
+    create_zip_from_directory(data_dir, &archive_path)?;
+    Ok(archive_path)
+}
+
+fn create_zip_from_directory(source_dir: &Path, archive_path: &Path) -> Result<(), String> {
+    let archive_file = File::create(archive_path).map_err(|e| {
+        format!(
+            "Failed to create archive '{}': {}",
+            archive_path.display(),
+            e
+        )
+    })?;
+    let mut zip = zip::ZipWriter::new(archive_file);
+
+    let dir_options = FileOptions::default().unix_permissions(0o755);
+    let file_options = FileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+
+    let mut buffer = Vec::new();
+
+    for entry in WalkDir::new(source_dir).follow_links(false) {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+
+        if path == source_dir {
+            continue;
+        }
+
+        let rel_path = path.strip_prefix(source_dir).map_err(|e| {
+            format!(
+                "Failed to build archive path for '{}': {}",
+                path.display(),
+                e
+            )
+        })?;
+        let rel_name = rel_path.to_string_lossy().replace('\\', "/");
+
+        if entry.file_type().is_dir() {
+            zip.add_directory(format!("{}/", rel_name), dir_options)
+                .map_err(|e| format!("Failed to add directory '{}' to zip: {}", rel_name, e))?;
+            continue;
+        }
+
+        if entry.file_type().is_file() {
+            zip.start_file(rel_name.clone(), file_options)
+                .map_err(|e| format!("Failed to add file '{}' to zip: {}", rel_name, e))?;
+            let mut input_file = File::open(path)
+                .map_err(|e| format!("Failed to open file '{}': {}", path.display(), e))?;
+            buffer.clear();
+            input_file
+                .read_to_end(&mut buffer)
+                .map_err(|e| format!("Failed to read file '{}': {}", path.display(), e))?;
+            zip.write_all(&buffer)
+                .map_err(|e| format!("Failed to write file '{}' to zip: {}", rel_name, e))?;
+        }
+    }
+
+    zip.finish().map_err(|e| {
+        format!(
+            "Failed to finish archive '{}': {}",
+            archive_path.display(),
+            e
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("vinylvault-archive-{label}-{nanos}"));
+        fs::create_dir_all(&path).expect("failed to create temp directory");
+        path
+    }
+
+    #[test]
+    fn create_archive_includes_db_and_cover_files() {
+        let root = make_temp_dir("content");
+        let data_dir = root.join("discos");
+        let cover_subdir = data_dir.join("covers").join("ab");
+        fs::create_dir_all(&cover_subdir).expect("failed to create cover subdir");
+
+        let db_path = data_dir.join("discos.sqlite");
+        let cover_path = cover_subdir.join("album_cd_hash.jpg");
+        fs::write(&db_path, b"sqlite-data").expect("failed to write db file");
+        fs::write(&cover_path, b"cover-data").expect("failed to write cover file");
+
+        let archive_path =
+            create_archive_with_date_suffix(&data_dir).expect("failed to create archive");
+        assert!(archive_path.exists());
+
+        let archive_file = File::open(&archive_path).expect("failed to open archive");
+        let mut archive =
+            zip::ZipArchive::new(archive_file).expect("failed to parse generated zip file");
+
+        assert!(archive.by_name("discos.sqlite").is_ok());
+        assert!(archive.by_name("covers/ab/album_cd_hash.jpg").is_ok());
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -573,9 +573,10 @@ async fn create_archive() -> Result<String, String> {
         .parent()
         .ok_or("Invalid database path: no parent directory")?
         .to_path_buf();
+    let db_path_for_archive = db_path.clone();
 
     tauri::async_runtime::spawn_blocking(move || {
-        archive::create_archive_with_date_suffix(&data_dir)
+        archive::create_archive_with_date_suffix(&data_dir, &db_path_for_archive)
             .map(|path| path.to_string_lossy().to_string())
     })
     .await

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -569,8 +569,16 @@ async fn import_mdb(
 #[tauri::command]
 async fn create_archive() -> Result<String, String> {
     let db_path = db::resolve_db_path()?;
+    if !db_path.is_absolute() {
+        return Err(
+            "Invalid database path: archive creation requires an absolute database path"
+                .to_string(),
+        );
+    }
+
     let data_dir = db_path
         .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
         .ok_or("Invalid database path: no parent directory")?
         .to_path_buf();
     let db_path_for_archive = db_path.clone();

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod archive;
 mod collation;
 mod cover_lookup;
 mod cover_storage;
@@ -565,6 +566,22 @@ async fn import_mdb(
     .map_err(|e| format!("Import task failed: {}", e))?
 }
 
+#[tauri::command]
+async fn create_archive() -> Result<String, String> {
+    let db_path = db::resolve_db_path()?;
+    let data_dir = db_path
+        .parent()
+        .ok_or("Invalid database path: no parent directory")?
+        .to_path_buf();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        archive::create_archive_with_date_suffix(&data_dir)
+            .map(|path| path.to_string_lossy().to_string())
+    })
+    .await
+    .map_err(|e| format!("Archive task failed: {}", e))?
+}
+
 /// Import an MDB file into a deterministic temporary directory for parser debugging.
 ///
 /// The temporary directory is deleted before every run so stale DB or cover files
@@ -661,6 +678,7 @@ pub fn run() {
             is_db_empty,
             check_for_updates,
             import_mdb,
+            create_archive,
         ])
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -442,11 +442,77 @@ body {
     font-weight: 600;
 }
 
+.nav-info-box {
+    min-width: 220px;
+    max-width: 36vw;
+    padding: 5px 10px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .nav-action-buttons {
     margin-left: auto;
     display: flex;
     align-items: center;
     gap: 10px;
+}
+
+.advanced-menu {
+    position: relative;
+}
+
+.advanced-trigger {
+    background: #ffffff;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.advanced-trigger:hover:not(:disabled) {
+    background: var(--color-border-light);
+}
+
+.advanced-dropdown {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    min-width: 190px;
+    background: #ffffff;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+    padding: 6px;
+    z-index: 12000;
+}
+
+.advanced-dropdown button {
+    width: 100%;
+    justify-content: flex-start;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    font-size: 13px;
+    font-weight: 500;
+    padding: 8px 10px;
+}
+
+.advanced-dropdown button:hover:not(:disabled) {
+    background: var(--color-bg-highlight);
+}
+
+.advanced-dropdown button:disabled {
+    opacity: 0.6;
+    cursor: wait;
 }
 
 .update-indicator {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -94,6 +94,17 @@ function App() {
 
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const [isCreatingArchive, setIsCreatingArchive] = useState(false);
+  const [activityText, setActivityText] = useState("");
+  const activityClearTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (activityClearTimeoutRef.current !== null) {
+        globalThis.clearTimeout(activityClearTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Check if DB is empty on mount
   useEffect(() => {
@@ -266,6 +277,35 @@ function App() {
     }
   }
 
+  async function handleCreateArchive() {
+    if (isCreatingArchive) {
+      return;
+    }
+
+    if (activityClearTimeoutRef.current !== null) {
+      globalThis.clearTimeout(activityClearTimeoutRef.current);
+      activityClearTimeoutRef.current = null;
+    }
+
+    setIsCreatingArchive(true);
+    setActivityText(t("activity.creating_archive"));
+    try {
+      const archivePath = await invoke<string>("create_archive");
+      setActivityText(t("activity.archive_created", { path: archivePath }));
+      activityClearTimeoutRef.current = globalThis.setTimeout(() => {
+        setActivityText("");
+        activityClearTimeoutRef.current = null;
+      }, 8000);
+      alert(t("advanced.archive_success", { path: archivePath }));
+    } catch (error) {
+      console.error("Failed to create archive:", error);
+      setActivityText(t("activity.archive_failed", { error }));
+      alert(t("advanced.archive_error", { error }));
+    } finally {
+      setIsCreatingArchive(false);
+    }
+  }
+
 
 
   if (isDbEmpty === null) {
@@ -330,6 +370,9 @@ function App() {
     onOpenReleasePage: handleOpenReleasePage,
     onAdd: handleAdd,
     onDelete: handleDelete,
+    onCreateArchive: handleCreateArchive,
+    isCreatingArchive,
+    activityText,
   };
 
   return (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -299,8 +299,10 @@ function App() {
       alert(t("advanced.archive_success", { path: archivePath }));
     } catch (error) {
       console.error("Failed to create archive:", error);
-      setActivityText(t("activity.archive_failed", { error }));
-      alert(t("advanced.archive_error", { error }));
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      setActivityText(t("activity.archive_failed", { error: errorMessage }));
+      alert(t("advanced.archive_error", { error: errorMessage }));
     } finally {
       setIsCreatingArchive(false);
     }

--- a/app/src/NavigationBar.tsx
+++ b/app/src/NavigationBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import Select from "react-select";
 import type { Theme, StylesConfig } from "react-select";
 import { useTranslation } from "react-i18next";
@@ -24,6 +25,9 @@ interface NavigationBarProps {
   onOpenReleasePage: () => Promise<void> | void;
   onAdd: () => Promise<void> | void;
   onDelete: () => void;
+  onCreateArchive: () => Promise<void> | void;
+  isCreatingArchive: boolean;
+  activityText: string;
   showSearchControls?: boolean;
   showBottomBar?: boolean;
 }
@@ -49,10 +53,50 @@ function NavigationBar({
   onOpenReleasePage,
   onAdd,
   onDelete,
+  onCreateArchive,
+  isCreatingArchive,
+  activityText,
   showSearchControls = true,
   showBottomBar = true,
 }: Readonly<NavigationBarProps>) {
   const { t } = useTranslation();
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+  const advancedMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isAdvancedOpen) {
+      return;
+    }
+
+    const onGlobalClick = (event: MouseEvent) => {
+      if (!advancedMenuRef.current) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof Node && !advancedMenuRef.current.contains(target)) {
+        setIsAdvancedOpen(false);
+      }
+    };
+
+    const onGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsAdvancedOpen(false);
+      }
+    };
+
+    globalThis.addEventListener("mousedown", onGlobalClick);
+    globalThis.addEventListener("keydown", onGlobalKeyDown);
+    return () => {
+      globalThis.removeEventListener("mousedown", onGlobalClick);
+      globalThis.removeEventListener("keydown", onGlobalKeyDown);
+    };
+  }, [isAdvancedOpen]);
+
+  const handleCreateArchiveClick = async () => {
+    setIsAdvancedOpen(false);
+    await onCreateArchive();
+  };
 
   return (
     <>
@@ -169,7 +213,35 @@ function NavigationBar({
           ⏭
         </button>
 
+        <div className="nav-info-box" aria-live="polite" title={activityText}>
+          {activityText}
+        </div>
+
         <div className="nav-action-buttons">
+          <div className="advanced-menu" ref={advancedMenuRef}>
+            <button
+              type="button"
+              className="advanced-trigger"
+              onClick={() => setIsAdvancedOpen((open) => !open)}
+              aria-haspopup="menu"
+              aria-expanded={isAdvancedOpen}
+              aria-label={t("advanced.title")}
+            >
+              ⚙️
+            </button>
+            {isAdvancedOpen && (
+              <div className="advanced-dropdown" role="menu">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleCreateArchiveClick}
+                  disabled={isCreatingArchive}
+                >
+                  {isCreatingArchive ? t("advanced.creating_archive") : t("advanced.create_archive")}
+                </button>
+              </div>
+            )}
+          </div>
           {updateInfo && (
             <button
               type="button"

--- a/app/src/NavigationBar.tsx
+++ b/app/src/NavigationBar.tsx
@@ -223,17 +223,15 @@ function NavigationBar({
               type="button"
               className="advanced-trigger"
               onClick={() => setIsAdvancedOpen((open) => !open)}
-              aria-haspopup="menu"
               aria-expanded={isAdvancedOpen}
               aria-label={t("advanced.title")}
             >
               ⚙️
             </button>
             {isAdvancedOpen && (
-              <div className="advanced-dropdown" role="menu">
+              <div className="advanced-dropdown">
                 <button
                   type="button"
-                  role="menuitem"
                   onClick={handleCreateArchiveClick}
                   disabled={isCreatingArchive}
                 >

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -98,5 +98,20 @@
     "tooltip": "Update available: {{version}}",
     "aria_label": "Open GitHub release {{version}}",
     "title": "A newer version is available"
+  },
+
+  "advanced": {
+    "title": "Advanced",
+    "create_archive": "Create archive",
+    "creating_archive": "Creating archive...",
+    "archive_success": "Archive created successfully: {{path}}",
+    "archive_error": "Error creating archive: {{error}}"
+  },
+
+  "activity": {
+    "ready": "Ready",
+    "creating_archive": "Creating backup archive...",
+    "archive_created": "Archive created: {{path}}",
+    "archive_failed": "Could not create archive: {{error}}"
   }
 }

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -98,5 +98,20 @@
     "tooltip": "Actualización disponible: {{version}}",
     "aria_label": "Abrir la versión {{version}} en GitHub",
     "title": "Hay una versión más reciente disponible"
+  },
+
+  "advanced": {
+    "title": "Avanzado",
+    "create_archive": "Crear archivo",
+    "creating_archive": "Creando archivo...",
+    "archive_success": "Archivo creado correctamente: {{path}}",
+    "archive_error": "Error al crear archivo: {{error}}"
+  },
+
+  "activity": {
+    "ready": "Listo",
+    "creating_archive": "Creando archivo de respaldo...",
+    "archive_created": "Archivo creado: {{path}}",
+    "archive_failed": "No se pudo crear el archivo: {{error}}"
   }
 }


### PR DESCRIPTION
Add a new feature for creating a backup archive of the application's data directory, accessible from an "Advanced" menu in the UI. The main changes include implementing the archive creation logic on the backend, exposing it as a Tauri command, and integrating a user interface for triggering and monitoring the archive process.